### PR TITLE
Fix session deletion after timeout

### DIFF
--- a/handlers/selenium.go
+++ b/handlers/selenium.go
@@ -96,7 +96,6 @@ func CreateSessionFromCache(sessionID string) (*session.Session, error) {
 		return nil, err
 	}
 
-	//sessionTimeout, err := getSessionTimeout(s.Caps.SessionTimeout, config.MaxTimeout, config.Timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -105,12 +104,8 @@ func CreateSessionFromCache(sessionID string) (*session.Session, error) {
 		Caps:     s.Caps,
 		URL:      s.URL,
 		HostPort: s.HostPort,
-		//Timeout:  s.Timeout,
-		//TimeoutCh: onTimeout(sessionTimeout, func() {
-		//	Delete(s.TaskID)
-		//}),
-		Started: s.Started,
-		TaskID:  s.TaskID,
+		Started:  s.Started,
+		TaskID:   s.TaskID,
 	}
 	seleniumSession.Cancel = cancelAndRenameFiles(s.TaskID)
 	return &seleniumSession, nil
@@ -287,7 +282,6 @@ func Create(c *gin.Context) {
 	}
 	var caps session.Caps
 	var starter service.Starter
-	//var sessionTimeout time.Duration
 	for _, fmc := range firstMatchCaps {
 		caps = browser.Caps
 		err := mergo.Merge(&caps, *fmc)
@@ -295,7 +289,6 @@ func Create(c *gin.Context) {
 			c.Error(err)
 		}
 		caps.ProcessExtensionCapabilities()
-		//sessionTimeout, err = getSessionTimeout(caps.SessionTimeout, config.MaxTimeout, config.Timeout)
 		if err != nil {
 			l.WithError(err).Error("Bas session timeout")
 			c.Error(creationError("Failed to parse `sessionTimeout` capability.", err)).SetType(gin.ErrorTypePublic)
@@ -410,11 +403,7 @@ func Create(c *gin.Context) {
 		Caps:     caps,
 		URL:      u,
 		HostPort: startedService.HostPort,
-		//Timeout:  sessionTimeout,
-		//TimeoutCh: onTimeout(sessionTimeout, func() {
-		//	Delete(startedService.TaskID)
-		//}),
-		Started: time.Now(),
+		Started:  time.Now(),
 	}
 
 	cancelAndRenameFiles := func() {
@@ -433,7 +422,6 @@ func Create(c *gin.Context) {
 		Caps:     sess.Caps,
 		URL:      sess.URL,
 		HostPort: sess.HostPort,
-		//Timeout:  sess.Timeout,
 		Started:  sess.Started,
 		TaskID:   startedService.TaskID,
 	}
@@ -522,11 +510,6 @@ func Proxy(c *gin.Context) {
 
 			sess.Lock.Lock()
 			defer sess.Lock.Unlock()
-			//select {
-			//case <-sess.TimeoutCh:
-			//default:
-			//	close(sess.TimeoutCh)
-			//}
 			if r.Method == http.MethodDelete && len(fragments) == 3 {
 				if config.EnableFileUpload {
 					os.RemoveAll(filepath.Join(os.TempDir(), sessionID))

--- a/session/session.go
+++ b/session/session.go
@@ -86,8 +86,6 @@ type Session struct {
 	Container *Container
 	HostPort  HostPort
 	Cancel    func()
-	//Timeout   time.Duration
-	//TimeoutCh chan struct{}
 	Started   time.Time
 	Lock      sync.Mutex
 	TaskID    string


### PR DESCRIPTION
We had two types of deletion after timeout
1. From management service
2. From main server. 

Deletion from main service doesn't work properly. So I deleted it.