### PR TITLE
Return list of downloads

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -84,6 +84,7 @@ func CreateRouter() *gin.Engine {
 		})
 
 		hub.GET("/download/:session/:file", handlers.Downloads)
+		hub.GET("/download/:session", handlers.Downloads)
 		hub.DELETE("/download/:session/:file", handlers.Downloads)
 		hub.HEAD("/download/:session/:file", handlers.Downloads)
 


### PR DESCRIPTION
Fix #203

Request to `/download/<session_id>` will return list of files in the following format
```html
<pre>
<a href="sample3.txt">sample3.txt</a>
</pre>
```

To download a specific file, you need to add it at the end of URL: `/download/<session_id>/sample3.txt`