### PR TITLE
Added support for null int capabilities

### DIFF
--- a/capabilities/capabilities.go
+++ b/capabilities/capabilities.go
@@ -88,7 +88,9 @@ type int64Wrapper int64
 func (i *int64Wrapper) Validate(key string, value interface{}) string {
 	errStr := ""
 
-	if valueFloat, ok := value.(float64); ok {
+	if value == nil {
+		i.From(0)
+	} else if valueFloat, ok := value.(float64); ok {
 		i.From(int64(valueFloat))
 	} else if valueStr, ok := value.(string); ok {
 		if valueInt, err := strconv.ParseInt(valueStr, 10, 64); err == nil {


### PR DESCRIPTION
with memory=null and cpu=0
`scaler    | time="2023-08-09T07:43:52Z" level=info msg="shape recorded" _taskId=0d4968402df44080931f5508b8f1770f request body="map[cpu:1024 millicores instant:2023-08-09T07:43:52Z memory:2048 MiB platform:cypress seconds:63.258674969999994 sessionId: taskId:0d4968402df44080931f5508b8f1770f]" workspace=devtests`