### PR TITLE
Add support of *-debug browser images

### DIFF
--- a/capabilities/parsing.go
+++ b/capabilities/parsing.go
@@ -90,6 +90,13 @@ func init() {
 			ValueProcessor: addArg("remote-allow-origins", "--remote-allow-origins=*"),
 		},
 		"browserVersion": {
+			ValueProcessor: func(value interface{}) interface{} {
+				// debug browser images tags should be like 125.0-debug
+				if v, ok := value.(string); ok {
+					return strings.TrimSuffix(v, "-debug")
+				}
+				return value
+			},
 			DeleteCapabilityProcessor: func(value interface{}) bool {
 				if version, ok := value.(string); ok {
 					version = strings.ToLower(version)

--- a/handlers/definitions.go
+++ b/handlers/definitions.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -42,10 +41,6 @@ func GetImages(c *gin.Context) {
 
 	imagesDataResponse := make([]imageDataModel, 0, len(images))
 	for _, image := range images {
-		if strings.Contains(image.Tag, "-debug") {
-			continue
-		}
-
 		imgData := imageDataModel{
 			Name:     image.BrowserName,
 			Version:  image.Tag,

--- a/handlers/reporting.go
+++ b/handlers/reporting.go
@@ -1,10 +1,12 @@
 package handlers
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -58,12 +60,21 @@ func ListDrivers(c *gin.Context) {
 		return
 	}
 
-	_, err = c.Writer.Write(resBody)
-	if err != nil {
-		c.Status(http.StatusInternalServerError)
-		log.WithError(err).Error("Failed to write body server")
+	originalImages := make([]imageDataModel, 0)
+	if err := json.Unmarshal(resBody, &originalImages); err != nil {
+		log.WithError(err).Error("Failed to unmarshal list of the images from task-definitions server")
 		return
 	}
+
+	filteredImages := make([]imageDataModel, 0)
+	for _, image := range originalImages {
+		// -debug images should not be added to the reporting, it should be available silently
+		if strings.Contains(image.Version, "-debug") {
+			continue
+		}
+		filteredImages = append(filteredImages, image)
+	}
+	c.JSON(http.StatusOK, filteredImages)
 }
 
 func Welcome(c *gin.Context) {


### PR DESCRIPTION
Instance:
<img width="342" alt="image" src="https://github.com/zebrunner/esg/assets/98826957/d31bbffe-1a9d-4037-add2-b064a48b0642">

Reporting:
<img width="313" alt="image" src="https://github.com/zebrunner/esg/assets/98826957/073a49ee-f69f-4ac7-859f-fa8a2f68bde9">
`-debug` image was not added to the browser list
<img width="245" alt="image" src="https://github.com/zebrunner/esg/assets/98826957/7af5f324-9d7b-4d02-be0b-10a628c43695">

